### PR TITLE
Add ARM64 archictecture (Apple silicon) support

### DIFF
--- a/ext/cld/base/build_config.h
+++ b/ext/cld/base/build_config.h
@@ -89,6 +89,11 @@
 #define ARCH_CPU_ARMEL 1
 #define ARCH_CPU_32_BITS 1
 #define WCHAR_T_IS_UNSIGNED 1
+#elif defined(__aarch64__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARM64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
 #else
 #error Please add support for your architecture in build/build_config.h
 #endif


### PR DESCRIPTION
Heavily inspired by #17 

Tested successfully on CI ( [Docker image armv7l](https://hub.docker.com/layers/ruby/library/ruby/3.0.2-alpine3.13/images/sha256-57ac5190124f0e637c63c42e8cc82c794e92bedfd494c69523ff71e60458921f?context=explore):
![image](https://user-images.githubusercontent.com/8051/126351115-ce7827fe-552f-454c-a92d-4d5c188701c5.png)

and on ARM64 M1 macbooks:
![image](https://user-images.githubusercontent.com/8051/126351211-5b39ff03-1c5f-40c3-a027-0b06c77116f9.png)

And on intel macbooks :)

Dear @grosser could you please release a new gem?
