### PR TITLE
Allow to compile the gem under Ruby 3.2

### DIFF
--- a/ext/cld/extconf.rb
+++ b/ext/cld/extconf.rb
@@ -4,4 +4,4 @@
 ENV['CFLAGS'] = ENV['CFLAGS'].to_s + ' -Wno-narrowing'
 ENV['CXXFLAGS'] = ENV['CXXFLAGS'].to_s + ' -Wno-narrowing'
 
-system "./configure --prefix=#{Dir.pwd}" unless File.exists?('Makefile')
+system "./configure --prefix=#{Dir.pwd}" unless File.exist?('Makefile')


### PR DESCRIPTION
`File#exists?` was deprecated in favor of `File#exist?` since Ruby 2.1. In Ruby 3.2 `File#exists?` has been finally removed.